### PR TITLE
preferences: Add a preference for the pretty display on maps

### DIFF
--- a/locales/en/main.json
+++ b/locales/en/main.json
@@ -259,6 +259,8 @@
     "DefaultColor": "Default color",
     "DefaultWalkingSpeedKph": "Default walking speed (km/h)",
     "DefaultWalkingSpeedKphHelp": "Walking speed varies according to age and gender between 3 km/h (elderly people and young children) and 7 km/h (young and/or very active people). Men are on average a little faster than women and in general, walking speed decreases with age. The speed of a person in a manual wheelchair varies between 2 and 3 km/h depending on physical strength.",
+    "ExperimentalFeatures": "Experimental features",
+    "MapPrettyDisplay": "Display pretty lines and nodes on map",
     "transit": {
       "nodes": {
       }

--- a/locales/fr/main.json
+++ b/locales/fr/main.json
@@ -259,6 +259,8 @@
     "DefaultColor": "Couleur par défaut",
     "DefaultWalkingSpeedKph": "Vitesse de marche par défaut (km/h)",
     "DefaultWalkingSpeedKphHelp": "La vitesse de marche varie selon l'âge et le genre entre 3 km/h (personnes âges et jeunes enfants) et 7 km/h (personnes jeunes et/ou très actives). Les hommes sont en moyenne un peu plus rapides que les femmes et de manière générale, la vitesse de marche diminue avec l'âge. La vitesse d'une personne en chaise roulante manuelle varie entre 2 et 3 km/h selon la force physique.",
+    "ExperimentalFeatures": "Fonctionnalités expérimentales",
+    "MapPrettyDisplay": "Affichage esthétique des lignes et noeuds sur la carte",
     "transit": {
       "nodes": {
       }

--- a/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/PreferencesEdit.tsx
@@ -23,6 +23,7 @@ import PreferencesSectionTransitLines from './sections/PreferencesSectionTransit
 import PreferencesSectionTransitPaths from './sections/PreferencesSectionTransitPaths';
 import PreferencesSectionTransitServices from './sections/PreferencesSectionTransitServices';
 import PreferencesSectionTransitScenarios from './sections/PreferencesSectionTransitScenarios';
+import PreferencesSectionFeatures from './sections/PreferencesSectionFeatures';
 
 type PreferencesPanelProps = WithTranslation;
 
@@ -132,6 +133,13 @@ class PreferencesPanel extends SaveableObjectForm<PreferencesClass, PreferencesP
                 />
 
                 <PreferencesSectionTransitScenarios
+                    preferences={this.state.object}
+                    onValueChange={this.onValueChange}
+                    resetChangesCount={this.resetChangesCount}
+                    resetPrefToDefault={this.resetPrefToDefault}
+                />
+
+                <PreferencesSectionFeatures
                     preferences={this.state.object}
                     onValueChange={this.onValueChange}
                     resetChangesCount={this.resetChangesCount}

--- a/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
+++ b/packages/transition-frontend/src/components/forms/preferences/sections/PreferencesSectionFeatures.tsx
@@ -1,0 +1,45 @@
+/*
+ * Copyright 2023, Polytechnique Montreal and contributors
+ *
+ * This file is licensed under the MIT License.
+ * License text available at https://opensource.org/licenses/MIT
+ */
+import React from 'react';
+import Collapsible from 'react-collapsible';
+import { withTranslation } from 'react-i18next';
+import _toString from 'lodash.tostring';
+import PreferencesResetToDefaultButton from '../PreferencesResetToDefaultButton';
+import InputWrapper from 'chaire-lib-frontend/lib/components/input/InputWrapper';
+import { InputCheckboxBoolean } from 'chaire-lib-frontend/lib/components/input/InputCheckbox';
+import PreferencesSectionProps from '../PreferencesSectionProps';
+
+const PreferencesSectionFeatures: React.FunctionComponent<PreferencesSectionProps> = (
+    props: PreferencesSectionProps
+) => {
+    const prefs = props.preferences.getAttributes();
+
+    return (
+        <Collapsible trigger={props.t('main:preferences:ExperimentalFeatures')} open={true} transitionTime={100}>
+            <div className="tr__form-section">
+                <InputWrapper twoColumns={true} label={props.t('main:preferences:MapPrettyDisplay')}>
+                    <InputCheckboxBoolean
+                        id={'formFieldPreferencesFeatureMapPrettyDisplay'}
+                        isChecked={props.preferences.get('features.map.prettyDisplay')}
+                        defaultChecked={false}
+                        label={props.t('main:Yes')}
+                        onValueChange={(e) =>
+                            props.onValueChange('features.map.prettyDisplay', { value: e.target.value })
+                        }
+                    />
+                    <PreferencesResetToDefaultButton
+                        resetPrefToDefault={props.resetPrefToDefault}
+                        path="features.map.prettyDisplay"
+                        preferences={props.preferences}
+                    />
+                </InputWrapper>
+            </div>
+        </Collapsible>
+    );
+};
+
+export default withTranslation(['main', 'transit'])(PreferencesSectionFeatures);


### PR DESCRIPTION
This adds a form component for the user to select whether to enable the aesthetic display of lines and nodes on the map. By default, it is not enabled.